### PR TITLE
Update remote before checking out new ref

### DIFF
--- a/baserock-export-git-submodules.py
+++ b/baserock-export-git-submodules.py
@@ -224,6 +224,11 @@ def create_or_update_submodule(path, repo, ref, gitdir):
                 logging.info("%s: Need to clone submodule", name, ref)
                 subprocess.check_call(
                     ['git', 'submodule', 'update', '--init', name], cwd=path)
+            else:
+                # We need to update the remote before checking out a new ref
+                subprocess.check_call(
+                    ['git', 'fetch', 'origin'], cwd=submodule_path)
+
             logging.info("%s: Checking out ref %s", name, ref)
             subprocess.check_call(
                 ['git', 'checkout', ref], cwd=submodule_path)


### PR DESCRIPTION
This was needed to fix the following error, after re-running the script.

```
INFO:root:definitions: At ref f3155082000fa595e5c10cd5c30e7ed14e93b994, wanted f06e708ce400f077505c378165997952e1bf1638
INFO:root:definitions: Checking out ref f06e708ce400f077505c378165997952e1bf1638
fatal: reference is not a tree: f06e708ce400f077505c378165997952e1bf1638
Traceback (most recent call last):
  File "/opt/baserock-export/baserock-export-git-submodules.py", line 314, in <module>
    main()
  File "/opt/baserock-export/baserock-export-git-submodules.py", line 311, in main
    create_or_update_git_megarepo(args.output_dir, repo_ref_pairs, mode)
  File "/opt/baserock-export/baserock-export-git-submodules.py", line 265, in create_or_update_git_megarepo
    create_or_update_submodule(path, repo, ref, gitdir)
  File "/opt/baserock-export/baserock-export-git-submodules.py", line 239, in create_or_update_submodule
    ['git', 'checkout', ref], cwd=submodule_path)
  File "/usr/lib64/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['git', 'checkout', 'f06e708ce400f077505c378165997952e1bf1638']' returned non-zero exit status 128
```
